### PR TITLE
Fixes Hugo stripping date of board report (blog post format)

### DIFF
--- a/source/comm/boardreports/2012-07-apache-vcl-board-report.md
+++ b/source/comm/boardreports/2012-07-apache-vcl-board-report.md
@@ -1,5 +1,6 @@
 ---
 title: 2012-07-25 Apache VCL Board Report
+slug: 2012-07-25-apache-vcl-board-report
 ---
 
 ### DESCRIPTION

--- a/source/comm/boardreports/2012-08-apache-vcl-board-report.md
+++ b/source/comm/boardreports/2012-08-apache-vcl-board-report.md
@@ -1,5 +1,6 @@
 ---
 title: 2012-08-15 Apache VCL Board Report
+slug: 2012-08-15-apache-vcl-board-report
 ---
 
 ### DESCRIPTION

--- a/source/comm/boardreports/2012-09-apache-vcl-board-report.md
+++ b/source/comm/boardreports/2012-09-apache-vcl-board-report.md
@@ -1,5 +1,6 @@
 ---
 title: 2012-09-19 Apache VCL Board Report
+slug: 2012-09-19-apache-vcl-board-report
 ---
 
 ### DESCRIPTION

--- a/source/comm/boardreports/2012-12-apache-vcl-board-report.md
+++ b/source/comm/boardreports/2012-12-apache-vcl-board-report.md
@@ -1,5 +1,6 @@
 ---
 title: 2012-12-19 Apache VCL Board Report
+slug: 2012-12-19-apache-vcl-board-report
 ---
 
 ### DESCRIPTION


### PR DESCRIPTION
This fixes a generation problem where Hugo sees the date as blog post format ignoring to generate the file. Adding the slug ensures no broken links are introduced.

/cc @jfthomps 